### PR TITLE
Proguard for Crashlytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # partyq
 
-[![niehusst](https://circleci.com/gh/niehusst/partyq.svg?style=svg)](https://app.circleci.com/pipelines/github/niehusst/partyq)
+[![niehusst](https://circleci.com/gh/niehusst/partyq-android.svg?style=svg)](https://app.circleci.com/pipelines/github/niehusst/partyq-android)
 
 partyq is a music queue app that uses Spotify to play music. If one person has Spotify premium (and the Spotify app on their device) they can use partyq to host a music party for a group of people with partyq who don't have Spotify (and are nearby/connected to the same wifi). Everyone connected to the party can search for and add songs to a shared queue, while the host device plays the music using Spotify.
     

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -28,9 +28,10 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# preserve the line number information for
+# debugging stack traces in firebase
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
@@ -98,6 +99,10 @@
 # keep all network serialized models
 -keep class com.niehusst.partyq.network.models.** { *; }
 
-
 # ignore unimportant warnings
 -dontwarn java.lang.instrument.ClassFileTransformer
+
+# keep crashlytics
+-keep class com.crashlytics.** { *; }
+-dontwarn com.crashlytics.**
+


### PR DESCRIPTION
Adds rules to keep line number for better crash report.
Also fixes broken ci badge in readme